### PR TITLE
Add daily cron rebuild for scheduled posts

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: ["main"]
 
+  # Rebuilds daily at 08:00 UTC to publish scheduled posts (future-dated, draft: false)
+  schedule:
+    - cron: '0 8 * * *'
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .hugo_build.lock
 /public
 /resources
+/content/ideas


### PR DESCRIPTION
## Summary
- Adds a daily 08:00 UTC cron trigger to the GitHub Actions workflow — future-dated posts (`draft: false` + future `date`) will go live automatically without a manual push
- Gitignores `/content/ideas` to keep the ideas backlog and schedule private

## Test plan
- [ ] Merge and confirm GitHub Actions shows the scheduled trigger active
- [ ] Verify a future-dated post does not appear until its date