### PR TITLE
Add footer disclaimer text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .hugo_build.lock
 /public
 /resources
-/content/ideas
+/content/posts/ideas

--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,7 @@ author = "Robin Carswell"
 description = "I do technology, product and business strategy projects in the UK. I spend my spare time on tech for good and venturebuilding."
 profilePicture = "images/rjc.png"
 copyright = "{{ YEAR }} Robin Carswell"
+disclaimer = "By reading this website, you agree, on behalf of your employer, to release me from all obligations and waivers arising from any and all NON-NEGOTIATED agreements, licenses, terms-of-service, shrinkwrap, clickwrap, browsewrap, confidentiality, non-disclosure, non-compete and acceptable use policies (\"BOGUS AGREEMENTS\") that I have entered into with your employer, its partners, licensors, agents and assigns, in perpetuity, without prejudice to my ongoing rights and privileges. You further represent that you have the authority to release me from any BOGUS AGREEMENTS on behalf of your employer."
 favicon = "/favicon/"
 mainSections = ["posts"]
 


### PR DESCRIPTION
## Summary
- Adds a configurable `disclaimer` param to the Anatole theme footer — works like `copyright`, set in `config.toml`
- Disclaimer text renders in small, muted text beneath the copyright line
- Populated with the employer waiver / BOGUS AGREEMENTS text

## Test plan
- [ ] Build locally and verify disclaimer appears beneath copyright
- [ ] Verify it renders correctly in dark mode
- [ ] Confirm removing the `disclaimer` param from config hides it entirely